### PR TITLE
Add modal to show full experience descriptions

### DIFF
--- a/src/components/ExperienceCard/index.tsx
+++ b/src/components/ExperienceCard/index.tsx
@@ -8,6 +8,7 @@ interface ExperienceCardProps {
   position: string;
   start_date: string;
   end_date: string | null;
+  onClick?: () => void;
 }
 
 export default function ExperienceCard({
@@ -16,9 +17,13 @@ export default function ExperienceCard({
   position,
   start_date,
   end_date,
+  onClick,
 }: ExperienceCardProps) {
   return (
-    <div className="w-[340px] h-[240px] mr-2 bg-green-800 rounded-md shadow-sm p-3 mb-2 inline-block bg-gradient-to-tl from-teal-900 via-emerald-800 to-green-700">
+    <div
+      onClick={onClick}
+      className="w-[340px] h-[240px] mr-2 bg-green-800 rounded-md shadow-sm p-3 mb-2 inline-block bg-gradient-to-tl from-teal-900 via-emerald-800 to-green-700 cursor-pointer"
+    >
       <strong>{companyName}</strong>
 
       <div className="flex">

--- a/src/components/ExperiencesCarousel/index.tsx
+++ b/src/components/ExperiencesCarousel/index.tsx
@@ -2,6 +2,7 @@ import { motion } from "framer-motion";
 import ExperienceCard from "../ExperienceCard/index";
 import { useEffect, useRef, useState } from "react";
 import { cutStringAndAddEllipsis } from "../../core/utils/string.utils";
+import Modal from "../Modal";
 
 interface ExperiencesCarouselProps {
   experiences: any[];
@@ -12,6 +13,7 @@ export default function ExperiencesCarousel({
 }: ExperiencesCarouselProps) {
   const carousel = useRef<any>();
   const [width, setWidth] = useState(0);
+  const [selectedExperience, setSelectedExperience] = useState<any | null>(null);
 
   useEffect(() => {
     setWidth(carousel.current?.scrollWidth - carousel.current?.offsetWidth);
@@ -20,50 +22,64 @@ export default function ExperiencesCarousel({
   const approximateCardSize: number = 280;
 
   return (
-    <motion.div
-      className="cursor-grab overflow-hidden w-[100%]"
-      ref={carousel}
-      whileTap={{ cursor: "grabbing" }}
-    >
+    <>
       <motion.div
-        dragConstraints={{
-          right: 0,
-          left: -approximateCardSize * experiences.length,
-        }}
-        drag="x"
-        className="flex"
-        initial={{ x: 100 }}
-        animate={{ x: 0 }}
-        transition={{ duration: 0.4 }}
+        className="cursor-grab overflow-hidden w-[100%]"
+        ref={carousel}
+        whileTap={{ cursor: "grabbing" }}
       >
-        {experiences
-          .sort((a, b) => {
-            const dateA: any = new Date(
-              a.start_date.split("/").reverse().join("-")
-            );
-            const dateB: any = new Date(
-              b.start_date.split("/").reverse().join("-")
-            );
-            return dateB - dateA;
-          })
-          .map((experience) => (
-            <ExperienceCard
-              companyName={experience.company}
-              position={experience.position}
-              start_date={experience.start_date}
-              end_date={experience.end_date}
-              key={experience.company + experience.start_date}
-            >
-              <ExperienceCard.Description>
-                {cutStringAndAddEllipsis(experience.description, 160)}
-              </ExperienceCard.Description>
+        <motion.div
+          dragConstraints={{
+            right: 0,
+            left: -approximateCardSize * experiences.length,
+          }}
+          drag="x"
+          className="flex"
+          initial={{ x: 100 }}
+          animate={{ x: 0 }}
+          transition={{ duration: 0.4 }}
+        >
+          {experiences
+            .sort((a, b) => {
+              const dateA: any = new Date(
+                a.start_date.split("/").reverse().join("-")
+              );
+              const dateB: any = new Date(
+                b.start_date.split("/").reverse().join("-")
+              );
+              return dateB - dateA;
+            })
+            .map((experience) => (
+              <ExperienceCard
+                companyName={experience.company}
+                position={experience.position}
+                start_date={experience.start_date}
+                end_date={experience.end_date}
+                key={experience.company + experience.start_date}
+                onClick={() => setSelectedExperience(experience)}
+              >
+                <ExperienceCard.Description>
+                  {cutStringAndAddEllipsis(experience.description, 160)}
+                </ExperienceCard.Description>
 
-              <ExperienceCard.Technologies
-                technologies={experience.technologies}
-              />
-            </ExperienceCard>
-          ))}
+                <ExperienceCard.Technologies
+                  technologies={experience.technologies}
+                />
+              </ExperienceCard>
+            ))}
+        </motion.div>
       </motion.div>
-    </motion.div>
+      <Modal
+        open={selectedExperience !== null}
+        onClose={() => setSelectedExperience(null)}
+        title={
+          selectedExperience
+            ? `${selectedExperience.company} - ${selectedExperience.position}`
+            : ""
+        }
+      >
+        {selectedExperience?.description}
+      </Modal>
+    </>
   );
 }

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+}
+
+export default function Modal({ open, onClose, title, children }: ModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70 p-4">
+      <div className="relative w-full max-w-xl bg-gray-900 text-white rounded-md shadow-lg p-6">
+        <button
+          className="absolute top-2 right-2 text-green-400 hover:text-green-300"
+          onClick={onClose}
+        >
+          X
+        </button>
+        {title && <h2 className="text-xl font-bold mb-4 text-green-400">{title}</h2>}
+        <div className="max-h-[70vh] overflow-y-auto whitespace-pre-line">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create Modal component with dark style and green details
- make ExperienceCard clickable
- update ExperiencesCarousel to open Modal with full description

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_683f71bff6a083208487b9b9253bc5a3