### PR TITLE
Improve experience timeline layout

### DIFF
--- a/src/components/ExperienceCard/index.tsx
+++ b/src/components/ExperienceCard/index.tsx
@@ -21,25 +21,17 @@ export default function ExperienceCard({
   onClick,
 }: ExperienceCardProps) {
   return (
-    <div
-      onClick={onClick}
-      className="w-full max-w-md bg-green-800 rounded-md shadow-sm p-3 mb-4 bg-gradient-to-tl from-teal-900 via-emerald-800 to-green-700 cursor-pointer"
-    >
-      <strong>{companyName}</strong>
-
-      <div className="flex">
-        <i>
-          <span className="block ">{position}</span>
-        </i>{" "}
-        -<span>{calcDiffOfDateExperience(start_date, end_date)}</span>
-      </div>
-
-      <div className="text-xs text-gray-300">
+    <div onClick={onClick} className="cursor-pointer">
+      <time className="mb-1 text-sm font-normal leading-none text-gray-400">
         {moment(start_date, "DD/MM/YYYY").format("DD-MM-YYYY")}
-        {end_date ?
-          ` - ${moment(end_date, "DD/MM/YYYY").format("DD-MM-YYYY")}` : ""}
+        {end_date ? ` - ${moment(end_date, "DD/MM/YYYY").format("DD-MM-YYYY")}` : ""}
+      </time>
+      <h3 className="text-lg font-semibold text-white">{companyName}</h3>
+      <div className="flex text-sm text-gray-200 mb-2">
+        <span>{position}</span>
+        <span className="mx-1">-</span>
+        <span>{calcDiffOfDateExperience(start_date, end_date)}</span>
       </div>
-
       {children}
     </div>
   );

--- a/src/components/ExperiencesCarousel/index.tsx
+++ b/src/components/ExperiencesCarousel/index.tsx
@@ -11,7 +11,10 @@ interface ExperiencesCarouselProps {
 export default function ExperiencesCarousel({ experiences }: ExperiencesCarouselProps) {
   const [selectedExperience, setSelectedExperience] = useState<any | null>(null);
 
-  const orderedExperiences = experiences.sort((a, b) => {
+  const orderedExperiences = [...experiences].sort((a, b) => {
+    if (!a.end_date && b.end_date) return -1;
+    if (!b.end_date && a.end_date) return 1;
+
     const dateA: any = new Date(a.start_date.split("/").reverse().join("-"));
     const dateB: any = new Date(b.start_date.split("/").reverse().join("-"));
     return dateB - dateA;
@@ -19,11 +22,13 @@ export default function ExperiencesCarousel({ experiences }: ExperiencesCarousel
 
   return (
     <>
-      <div className="relative pl-8">
-        <div className="absolute left-2 top-0 bottom-0 w-1 bg-green-700"></div>
+      <ol className="relative border-s border-green-700">
         {orderedExperiences.map((experience) => (
-          <div key={experience.company + experience.start_date} className="relative pb-8">
-            <span className="absolute -left-3 top-5 w-3 h-3 bg-green-500 rounded-full"></span>
+          <li
+            key={experience.company + experience.start_date}
+            className="mb-10 ms-4"
+          >
+            <div className="absolute w-3 h-3 bg-green-500 rounded-full mt-1 -start-1.5 border border-white"></div>
             <ExperienceCard
               companyName={experience.company}
               position={experience.position}
@@ -36,9 +41,9 @@ export default function ExperiencesCarousel({ experiences }: ExperiencesCarousel
               </ExperienceCard.Description>
               <ExperienceCard.Technologies technologies={experience.technologies} />
             </ExperienceCard>
-          </div>
+          </li>
         ))}
-      </div>
+      </ol>
       <Modal
         open={selectedExperience !== null}
         onClose={() => setSelectedExperience(null)}


### PR DESCRIPTION
## Summary
- restyle `ExperienceCard` content to remove card background
- refactor `ExperiencesCarousel` to use `<ol>`/`<li>` structure similar to Flowbite timeline
- order ongoing experiences first in the timeline

## Testing
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68421cc56ab88320be19e2c0e128a77f