### PR TITLE
Add expandable experience descriptions

### DIFF
--- a/src/components/ExperienceCard/components/ExperienceCardDescription/index.tsx
+++ b/src/components/ExperienceCard/components/ExperienceCardDescription/index.tsx
@@ -1,10 +1,26 @@
-import { ReactNode } from "react";
+import { useState } from "react";
+import { cutStringAndAddEllipsis } from "../../../../core/utils/string.utils";
+
 interface ExperienceCardDescriptionProps {
-  children: ReactNode;
+  text: string;
 }
 
-export default function ExperienceCardDescription({
-  children,
-}: ExperienceCardDescriptionProps) {
-  return <p className="whitespace-pre-line w-[300px] h-[68%]">{children}</p>;
+export default function ExperienceCardDescription({ text }: ExperienceCardDescriptionProps) {
+  const [expanded, setExpanded] = useState(false);
+  const shouldTruncate = text.length > 160;
+  const displayedText = expanded ? text : cutStringAndAddEllipsis(text, 160);
+
+  return (
+    <p className="whitespace-pre-line w-[300px]">
+      {displayedText}
+      {shouldTruncate && (
+        <span
+          onClick={() => setExpanded(!expanded)}
+          className="text-green-400 cursor-pointer ml-1"
+        >
+          {expanded ? " Ler menos" : " Ler mais"}
+        </span>
+      )}
+    </p>
+  );
 }

--- a/src/components/ExperienceCard/index.tsx
+++ b/src/components/ExperienceCard/index.tsx
@@ -9,7 +9,6 @@ interface ExperienceCardProps {
   position: string;
   start_date: string;
   end_date: string | null;
-  onClick?: () => void;
 }
 
 export default function ExperienceCard({
@@ -18,10 +17,9 @@ export default function ExperienceCard({
   position,
   start_date,
   end_date,
-  onClick,
 }: ExperienceCardProps) {
   return (
-    <div onClick={onClick} className="cursor-pointer">
+    <div>
       <time className="mb-1 text-sm font-normal leading-none text-gray-400">
         {moment(start_date, "DD/MM/YYYY").format("DD-MM-YYYY")}
         {end_date ? ` - ${moment(end_date, "DD/MM/YYYY").format("DD-MM-YYYY")}` : ""}

--- a/src/components/ExperiencesCarousel/index.tsx
+++ b/src/components/ExperiencesCarousel/index.tsx
@@ -1,15 +1,10 @@
 import ExperienceCard from "../ExperienceCard";
-import { useState } from "react";
-import { cutStringAndAddEllipsis } from "../../core/utils/string.utils";
-import Modal from "../Modal";
-import moment from "moment";
 
 interface ExperiencesCarouselProps {
   experiences: any[];
 }
 
 export default function ExperiencesCarousel({ experiences }: ExperiencesCarouselProps) {
-  const [selectedExperience, setSelectedExperience] = useState<any | null>(null);
 
   const orderedExperiences = [...experiences].sort((a, b) => {
     if (!a.end_date && b.end_date) return -1;
@@ -34,38 +29,13 @@ export default function ExperiencesCarousel({ experiences }: ExperiencesCarousel
               position={experience.position}
               start_date={experience.start_date}
               end_date={experience.end_date}
-              onClick={() => setSelectedExperience(experience)}
             >
-              <ExperienceCard.Description>
-                {cutStringAndAddEllipsis(experience.description, 160)}
-              </ExperienceCard.Description>
+              <ExperienceCard.Description text={experience.description} />
               <ExperienceCard.Technologies technologies={experience.technologies} />
             </ExperienceCard>
           </li>
         ))}
       </ol>
-      <Modal
-        open={selectedExperience !== null}
-        onClose={() => setSelectedExperience(null)}
-        title={
-          selectedExperience
-            ? `${selectedExperience.company} - ${selectedExperience.position}`
-            : ""
-        }
-      >
-        {selectedExperience && (
-          <div className="mb-4 text-sm text-gray-300">
-            {moment(selectedExperience.start_date, "DD/MM/YYYY").format("DD-MM-YYYY")}
-            {selectedExperience.end_date && (
-              <>
-                {" - "}
-                {moment(selectedExperience.end_date, "DD/MM/YYYY").format("DD-MM-YYYY")}
-              </>
-            )}
-          </div>
-        )}
-        {selectedExperience?.description}
-      </Modal>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add toggling ability for experience descriptions with a "Ler mais" link
- remove modal usage from the experiences carousel

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6842258473c083209cc6c99ef9a02394